### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,5 +1,8 @@
 name: Rust CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/tunamaguro/messagepack-rs/security/code-scanning/6](https://github.com/tunamaguro/messagepack-rs/security/code-scanning/6)

To resolve the issue, the `permissions` key should be added to the workflow to explicitly define the required permissions. Since none of the jobs require write access, we can set permissions to `contents: read` at the root level, which applies to all jobs unless overridden. This ensures that the workflow strictly adheres to the principle of least privilege.

Changes should be made at the root of the workflow file (`.github/workflows/pull_request.yaml`) to add the `permissions` block. This prevents the use of default repository permissions and constrains the `GITHUB_TOKEN` to only have read access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
