### PR TITLE
Add `Any` decoder for compact MessagePack value summaries

### DIFF
--- a/messagepack-core/src/decode/any.rs
+++ b/messagepack-core/src/decode/any.rs
@@ -1,0 +1,303 @@
+//! Decode arbitrary MessagePack values into a compact summary enum.
+
+use super::{DecodeBorrowed, Error, NbyteReader};
+use crate::{
+    Format,
+    io::{IoRead, Reference},
+};
+
+/// String value summary.
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AnyStr<'de> {
+    /// Borrowed UTF-8 string.
+    Borrowed(&'de str),
+    /// Length only (bytes).
+    Len(usize),
+}
+
+/// Binary value summary.
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AnyBin<'de> {
+    /// Borrowed raw bytes.
+    Borrowed(&'de [u8]),
+    /// Length only (bytes).
+    Len(usize),
+}
+
+/// Extension value summary.
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AnyExt<'de> {
+    /// Borrowed extension payload.
+    Borrowed {
+        /// Extension type code.
+        r#type: i8,
+        /// Borrowed payload bytes.
+        data: &'de [u8],
+    },
+    /// Type and payload length only.
+    Len {
+        /// Extension type code.
+        r#type: i8,
+        /// Payload length in bytes.
+        len: usize,
+    },
+}
+
+/// A compact, recursively-skipping representation of one decoded MessagePack value.
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub enum Any<'de> {
+    /// `nil`
+    Nil,
+    /// `bool`
+    Bool(bool),
+    /// Unsigned integer value.
+    UInt(u64),
+    /// Signed integer value.
+    Int(i64),
+    /// 32-bit float.
+    F32(f32),
+    /// 64-bit float.
+    F64(f64),
+    /// String summary.
+    Str(AnyStr<'de>),
+    /// Binary summary.
+    Bin(AnyBin<'de>),
+    /// Number of elements in array.
+    Array(usize),
+    /// Number of entries in map.
+    Map(usize),
+    /// Extension summary.
+    Ext(AnyExt<'de>),
+}
+
+#[cfg(feature = "alloc")]
+impl<'de> DecodeBorrowed<'de> for Any<'de> {
+    type Value = Self;
+
+    fn decode_borrowed_with_format<R>(
+        format: Format,
+        reader: &mut R,
+    ) -> core::result::Result<Self::Value, Error<R::Error>>
+    where
+        R: IoRead<'de>,
+    {
+        match format {
+            Format::Nil => Ok(Self::Nil),
+            Format::False => Ok(Self::Bool(false)),
+            Format::True => Ok(Self::Bool(true)),
+
+            Format::PositiveFixInt(v) => Ok(Self::UInt(v.into())),
+            Format::Uint8 => Ok(Self::UInt(read_u8(reader)?.into())),
+            Format::Uint16 => Ok(Self::UInt(read_u16(reader)?.into())),
+            Format::Uint32 => Ok(Self::UInt(read_u32(reader)?.into())),
+            Format::Uint64 => Ok(Self::UInt(read_u64(reader)?)),
+
+            Format::NegativeFixInt(v) => Ok(Self::Int(v.into())),
+            Format::Int8 => Ok(Self::Int(read_i8(reader)?.into())),
+            Format::Int16 => Ok(Self::Int(read_i16(reader)?.into())),
+            Format::Int32 => Ok(Self::Int(read_i32(reader)?.into())),
+            Format::Int64 => Ok(Self::Int(read_i64(reader)?)),
+
+            Format::Float32 => Ok(Self::F32(f32::decode_borrowed_with_format(format, reader)?)),
+            Format::Float64 => Ok(Self::F64(f64::decode_borrowed_with_format(format, reader)?)),
+
+            Format::FixStr(_) | Format::Str8 | Format::Str16 | Format::Str32 => {
+                decode_str(format, reader)
+            }
+
+            Format::Bin8 | Format::Bin16 | Format::Bin32 => {
+                let len = bin_len(format, reader)?;
+                match reader.read_slice(len).map_err(Error::Io)? {
+                    Reference::Borrowed(v) => Ok(Self::Bin(AnyBin::Borrowed(v))),
+                    Reference::Copied(_) => Ok(Self::Bin(AnyBin::Len(len))),
+                }
+            }
+
+            Format::FixArray(_) | Format::Array16 | Format::Array32 => {
+                let len = array_len(format, reader)?;
+                for _ in 0..len {
+                    let _ = Self::decode_borrowed(reader)?;
+                }
+                Ok(Self::Array(len))
+            }
+
+            Format::FixMap(_) | Format::Map16 | Format::Map32 => {
+                let len = map_len(format, reader)?;
+                for _ in 0..len {
+                    let _ = Self::decode_borrowed(reader)?;
+                    let _ = Self::decode_borrowed(reader)?;
+                }
+                Ok(Self::Map(len))
+            }
+
+            Format::FixExt1
+            | Format::FixExt2
+            | Format::FixExt4
+            | Format::FixExt8
+            | Format::FixExt16
+            | Format::Ext8
+            | Format::Ext16
+            | Format::Ext32 => {
+                let (len, r#type) = crate::extension::read_ext_header(format, reader)?;
+                match reader.read_slice(len).map_err(Error::Io)? {
+                    Reference::Borrowed(data) => Ok(Self::Ext(AnyExt::Borrowed { r#type, data })),
+                    Reference::Copied(_) => Ok(Self::Ext(AnyExt::Len { r#type, len })),
+                }
+            }
+
+            Format::NeverUsed => Err(Error::UnexpectedFormat),
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+fn decode_str<'de, R>(format: Format, reader: &mut R) -> Result<Any<'de>, Error<R::Error>>
+where
+    R: IoRead<'de>,
+{
+    let len = match format {
+        Format::FixStr(n) => n.into(),
+        Format::Str8 => NbyteReader::<1>::read(reader)?,
+        Format::Str16 => NbyteReader::<2>::read(reader)?,
+        Format::Str32 => NbyteReader::<4>::read(reader)?,
+        _ => return Err(Error::UnexpectedFormat),
+    };
+
+    match reader.read_slice(len).map_err(Error::Io)? {
+        Reference::Borrowed(bytes) => {
+            let s = core::str::from_utf8(bytes).map_err(|_| Error::InvalidData)?;
+            Ok(Any::Str(AnyStr::Borrowed(s)))
+        }
+        Reference::Copied(bytes) => {
+            core::str::from_utf8(bytes).map_err(|_| Error::InvalidData)?;
+            Ok(Any::Str(AnyStr::Len(len)))
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+fn bin_len<'de, R>(format: Format, reader: &mut R) -> Result<usize, Error<R::Error>>
+where
+    R: IoRead<'de>,
+{
+    match format {
+        Format::Bin8 => NbyteReader::<1>::read(reader),
+        Format::Bin16 => NbyteReader::<2>::read(reader),
+        Format::Bin32 => NbyteReader::<4>::read(reader),
+        _ => Err(Error::UnexpectedFormat),
+    }
+}
+
+#[cfg(feature = "alloc")]
+fn array_len<'de, R>(format: Format, reader: &mut R) -> Result<usize, Error<R::Error>>
+where
+    R: IoRead<'de>,
+{
+    match format {
+        Format::FixArray(v) => Ok(v.into()),
+        Format::Array16 => NbyteReader::<2>::read(reader),
+        Format::Array32 => NbyteReader::<4>::read(reader),
+        _ => Err(Error::UnexpectedFormat),
+    }
+}
+
+#[cfg(feature = "alloc")]
+fn map_len<'de, R>(format: Format, reader: &mut R) -> Result<usize, Error<R::Error>>
+where
+    R: IoRead<'de>,
+{
+    match format {
+        Format::FixMap(v) => Ok(v.into()),
+        Format::Map16 => NbyteReader::<2>::read(reader),
+        Format::Map32 => NbyteReader::<4>::read(reader),
+        _ => Err(Error::UnexpectedFormat),
+    }
+}
+
+#[cfg(feature = "alloc")]
+fn read_u8<'de, R>(reader: &mut R) -> Result<u8, Error<R::Error>>
+where
+    R: IoRead<'de>,
+{
+    let bytes = reader.read_slice(1).map_err(Error::Io)?;
+    let data: [u8; 1] = bytes
+        .as_bytes()
+        .try_into()
+        .map_err(|_| Error::UnexpectedEof)?;
+    Ok(data[0])
+}
+
+#[cfg(feature = "alloc")]
+fn read_i8<'de, R>(reader: &mut R) -> Result<i8, Error<R::Error>>
+where
+    R: IoRead<'de>,
+{
+    Ok(read_u8(reader)? as i8)
+}
+
+#[cfg(feature = "alloc")]
+fn read_u16<'de, R>(reader: &mut R) -> Result<u16, Error<R::Error>>
+where
+    R: IoRead<'de>,
+{
+    let bytes = reader.read_slice(2).map_err(Error::Io)?;
+    let data: [u8; 2] = bytes
+        .as_bytes()
+        .try_into()
+        .map_err(|_| Error::UnexpectedEof)?;
+    Ok(u16::from_be_bytes(data))
+}
+
+#[cfg(feature = "alloc")]
+fn read_i16<'de, R>(reader: &mut R) -> Result<i16, Error<R::Error>>
+where
+    R: IoRead<'de>,
+{
+    Ok(read_u16(reader)? as i16)
+}
+
+#[cfg(feature = "alloc")]
+fn read_u32<'de, R>(reader: &mut R) -> Result<u32, Error<R::Error>>
+where
+    R: IoRead<'de>,
+{
+    let bytes = reader.read_slice(4).map_err(Error::Io)?;
+    let data: [u8; 4] = bytes
+        .as_bytes()
+        .try_into()
+        .map_err(|_| Error::UnexpectedEof)?;
+    Ok(u32::from_be_bytes(data))
+}
+
+#[cfg(feature = "alloc")]
+fn read_i32<'de, R>(reader: &mut R) -> Result<i32, Error<R::Error>>
+where
+    R: IoRead<'de>,
+{
+    Ok(read_u32(reader)? as i32)
+}
+
+#[cfg(feature = "alloc")]
+fn read_u64<'de, R>(reader: &mut R) -> Result<u64, Error<R::Error>>
+where
+    R: IoRead<'de>,
+{
+    let bytes = reader.read_slice(8).map_err(Error::Io)?;
+    let data: [u8; 8] = bytes
+        .as_bytes()
+        .try_into()
+        .map_err(|_| Error::UnexpectedEof)?;
+    Ok(u64::from_be_bytes(data))
+}
+
+#[cfg(feature = "alloc")]
+fn read_i64<'de, R>(reader: &mut R) -> Result<i64, Error<R::Error>>
+where
+    R: IoRead<'de>,
+{
+    Ok(read_u64(reader)? as i64)
+}

--- a/messagepack-core/src/decode/mod.rs
+++ b/messagepack-core/src/decode/mod.rs
@@ -4,6 +4,10 @@ use crate::{Format, io::IoRead};
 
 mod array;
 pub use array::ArrayDecoder;
+#[cfg(feature = "alloc")]
+mod any;
+#[cfg(feature = "alloc")]
+pub use any::{Any, AnyBin, AnyExt, AnyStr};
 mod bin;
 #[cfg(feature = "alloc")]
 pub use bin::BinOwnedDecoder;

--- a/messagepack-core/tests/any.rs
+++ b/messagepack-core/tests/any.rs
@@ -1,8 +1,10 @@
 use messagepack_core::{
-    decode::{Decode, DecodeBorrowed, Error as DecodeError, NilDecoder},
+    decode::{
+        Any, AnyBin, AnyExt, AnyStr, Decode, DecodeBorrowed, Error as DecodeError, NilDecoder,
+    },
     encode::{BinaryEncoder, Encode, Error as EncodeError, NilEncoder},
     extension::ExtensionOwned,
-    io::{IoRead, IoWrite, SliceReader, VecRefWriter},
+    io::{IoRead, IoWrite, IterReader, SliceReader, VecRefWriter},
 };
 use proptest::prelude::*;
 
@@ -209,4 +211,51 @@ proptest! {
 
         assert_eq!(x,y);
     }
+}
+
+#[test]
+fn decode_any_single_value() {
+    let mut map = std::collections::BTreeMap::new();
+    map.insert(String::from("ok"), MessagePackType::Bool(true));
+
+    let value = MessagePackType::Array(vec![
+        MessagePackType::Nil,
+        MessagePackType::Integer(Integer::I64(-10)),
+        MessagePackType::Float(Float::F32(1.5)),
+        MessagePackType::Str(String::from("hello")),
+        MessagePackType::Bin(vec![1, 2, 3]),
+        MessagePackType::Map(map),
+        MessagePackType::Ext(ExtensionOwned::new(1, vec![9, 8])),
+    ]);
+
+    let mut buf = vec![];
+    let mut writer = VecRefWriter::new(&mut buf);
+    value.encode(&mut writer).unwrap();
+
+    let mut reader = SliceReader::new(buf.as_slice());
+    let decoded = Any::decode(&mut reader).unwrap();
+
+    assert_eq!(decoded, Any::Array(7));
+    assert!(reader.rest().is_empty());
+}
+
+#[test]
+fn decode_any_copied_becomes_len() {
+    let mut buf = vec![];
+    let mut writer = VecRefWriter::new(&mut buf);
+    String::from("hello").encode(&mut writer).unwrap();
+    BinaryEncoder(&[1, 2, 3, 4]).encode(&mut writer).unwrap();
+    ExtensionOwned::new(3, vec![9, 8, 7])
+        .encode(&mut writer)
+        .unwrap();
+
+    let mut iter = IterReader::new(buf.into_iter());
+
+    let a = Any::decode(&mut iter).unwrap();
+    let b = Any::decode(&mut iter).unwrap();
+    let c = Any::decode(&mut iter).unwrap();
+
+    assert_eq!(a, Any::Str(AnyStr::Len(5)));
+    assert_eq!(b, Any::Bin(AnyBin::Len(4)));
+    assert_eq!(c, Any::Ext(AnyExt::Len { r#type: 3, len: 3 }));
 }


### PR DESCRIPTION
### Motivation

- Provide a compact, recursively-skipping representation for arbitrary MessagePack values so callers can inspect or skip values without fully deserializing or unnecessarily copying payloads.
- Support borrowed and length-only summaries for strings, binaries, and extension payloads when the `alloc` feature is enabled.

### Description

- Add `messagepack-core/src/decode/any.rs` which defines `Any`, `AnyStr`, `AnyBin`, and `AnyExt` enums and implements `DecodeBorrowed` for `Any` to decode MessagePack formats into compact summaries. 
- Implement helpers in `any.rs` for reading sized fields and multi-byte integers (`read_u8`..`read_i64`), and helper functions `decode_str`, `bin_len`, `array_len`, and `map_len` to parse length-prefixed types. 
- Make `Any` and related types public from `messagepack-core/src/decode/mod.rs` behind the `alloc` feature by adding the module and `pub use` entries. 
- Extend `messagepack-core/tests/any.rs` to exercise the new decoder, update imports to use `IterReader`, and add unit tests `decode_any_single_value` and `decode_any_copied_becomes_len` plus the existing `proptest` roundtrip test. 

### Testing

- Ran `cargo test` for the crate and the added tests including the `proptest` property `roundtrip_any`, and the unit tests `decode_any_single_value` and `decode_any_copied_becomes_len`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d59618784c832fb56564e51ba3602f)